### PR TITLE
Add `class` argument to txt_style() by way of wrap_html()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## New features
 
-
+- `txt_style()` now accepts a `class` argument specifying a vector of classes to
+  be applied to the `<span>` of the decorated text (@gadenbuie, #18).
 
 ## Bugs and fixes
 

--- a/R/txt_style.R
+++ b/R/txt_style.R
@@ -1,7 +1,8 @@
 #' Wraps text in html or latex code for formatting
 #'
 #' \code{txt_style} adds appropriate html style wrappers to a string.
-#' Any number of options can be specified, as long as they match html CSS tags names.
+#' Any number of options can be specified, as long as they match html CSS
+#' property names.
 #'
 #' \code{txt_*} are shortcuts for specific individual style options
 #'
@@ -16,6 +17,7 @@
 #' @param underline Should the text be underlined?
 #' @param italics Should the text be italicized?
 #' @param font A valid font family.
+#' @inheritParams wrap_html
 #' @param ... various display options: any html CSS \code{style} options, or one
 #' of \code{font}, \code{size}, \code{color}, \code{background}, \code{style}.
 #'
@@ -37,10 +39,14 @@
 #' # Code styling wrapper
 #' txt_tocode("I am code.")
 #'
+#' # Can also use classes
+#' txt_style("I am danger", class = "text-danger")
+#'
 #' @export
 txt_style <- function(x,
                       type = "html",
                       bold = FALSE, underline = FALSE, italics = FALSE,
+                      class = NULL,
                       ...) {
 
   # Dots to list
@@ -49,7 +55,7 @@ txt_style <- function(x,
   # If html to correct <span> options
   if (type == "html") {
 
-    if (length(my_opts) != 0) {
+    if (length(my_opts) != 0 || !is.null(class)) {
 
       # replacements to pass to str_replace
       opts_to_html = c("^size" = "font-size",
@@ -72,7 +78,7 @@ txt_style <- function(x,
 
 
       # put all options into <span>
-      x <- wrap_html(x, my_opts)
+      x <- wrap_html(x, my_opts, class = class)
 
     } #if options exist
 

--- a/R/txt_style.R
+++ b/R/txt_style.R
@@ -64,11 +64,11 @@ txt_style <- function(x,
 
       # check for bold, italics, underline
 
-      if (bold) { my_opts <- c(my_opts, "bold" = "text-weight") }
+      if (bold) { my_opts <- c(my_opts, "text-weight" = "bold") }
 
-      if (italics) { my_opts <- c(my_opts, "italics" = "text-style") }
+      if (italics) { my_opts <- c(my_opts, "text-style" = "italics") }
 
-      if (underline) { my_opts <- c(my_opts, "underline" = "text-decoration") }
+      if (underline) { my_opts <- c(my_opts, "text-decoration" = "underline") }
 
 
       # put all options into <span>

--- a/R/utils-wrap.R
+++ b/R/utils-wrap.R
@@ -7,14 +7,26 @@
 #' @param opts_list The html options to include, in named vector form
 #' @param type The style of display, defaults to "html"
 #' (currently nothing else is supported, sorry)
+#' @param class CSS classes applied to the `<span>` tag wrapping the text.
 #'
 #' @export
-wrap_html <- function(x, opts_list, type = "html"){
+wrap_html <- function(x, opts_list, type = "html", class = NULL){
 
   span_string <- stringr::str_c(names(opts_list), opts_list, sep = ":") %>%
     stringr::str_c(collapse = ";")
 
-  x <- glue::glue("<span style='{span_string}'>{x}</span>")
+  span_style_string <- if (nzchar(span_string)) {
+    glue::glue('style="{span_string}"')
+  }
+
+  span_class_string <- if (!is.null(class) && any(!is.na(class)) && any(nzchar(class))) {
+    class <- class[!is.na(class) & nzchar(class)]
+    class <- paste(class, collapse = " ")
+    glue::glue('class="{class}"')
+  }
+
+  span_attributes <- paste(c("", span_class_string, span_style_string), collapse = " ")
+  x <- glue::glue("<span{span_attributes}>{x}</span>")
 
   return(x)
 

--- a/man/txt_style.Rd
+++ b/man/txt_style.Rd
@@ -20,6 +20,7 @@ txt_style(
   bold = FALSE,
   underline = FALSE,
   italics = FALSE,
+  class = NULL,
   ...
 )
 
@@ -55,6 +56,8 @@ txt_tag(x, before, after)
 
 \item{italics}{Should the text be italicized?}
 
+\item{class}{CSS classes applied to the `<span>` tag wrapping the text.}
+
 \item{...}{various display options: any html CSS \code{style} options, or one
 of \code{font}, \code{size}, \code{color}, \code{background}, \code{style}.}
 
@@ -77,7 +80,8 @@ A string containing \code{x} with html wrappers.
 }
 \description{
 \code{txt_style} adds appropriate html style wrappers to a string.
-Any number of options can be specified, as long as they match html CSS tags names.
+Any number of options can be specified, as long as they match html CSS
+property names.
 }
 \details{
 \code{txt_*} are shortcuts for specific individual style options
@@ -97,6 +101,9 @@ txt_color("I am blue.", color = "blue")
 
 # Code styling wrapper
 txt_tocode("I am code.")
+
+# Can also use classes
+txt_style("I am danger", class = "text-danger")
 
 }
 \seealso{

--- a/man/wrap_html.Rd
+++ b/man/wrap_html.Rd
@@ -4,7 +4,7 @@
 \alias{wrap_html}
 \title{Wraps text in html for formatting}
 \usage{
-wrap_html(x, opts_list, type = "html")
+wrap_html(x, opts_list, type = "html", class = NULL)
 }
 \arguments{
 \item{x}{The string to be wrapped}
@@ -13,6 +13,8 @@ wrap_html(x, opts_list, type = "html")
 
 \item{type}{The style of display, defaults to "html"
 (currently nothing else is supported, sorry)}
+
+\item{class}{CSS classes applied to the `<span>` tag wrapping the text.}
 }
 \description{
 \code{wrap_html} returns a string with styling wrappers from a list of style

--- a/tests/testthat/test-flair.R
+++ b/tests/testthat/test-flair.R
@@ -3,7 +3,7 @@ test_regexp = "Sepal\\.[:alnum:]*"
 
 test_that("flair_rx works without dots", {
 
-  good_str = "ggplot(iris, aes(x = <span style='background-color:#ffff7f'>Sepal.Length</span>)) + geom_histogram()"
+  good_str = "ggplot(iris, aes(x = <span style=\"background-color:#ffff7f\">Sepal.Length</span>)) + geom_histogram()"
 
   expect_equal(flair_rx(test_str, test_regexp), good_str)
 })
@@ -12,7 +12,7 @@ test_that("flair_rx works without dots", {
 
 test_that("flair_rx works with dots", {
 
-  good_str = "ggplot(iris, aes(x = <span style='color:red;font-size:30px'>Sepal.Length</span>)) + geom_histogram()"
+  good_str = "ggplot(iris, aes(x = <span style=\"color:red;font-size:30px\">Sepal.Length</span>)) + geom_histogram()"
 
   res_test <- flair_rx(test_str, test_regexp, color = "red", size = "30px")
 
@@ -22,9 +22,9 @@ test_that("flair_rx works with dots", {
 
 test_that("flair_rx works for with_flair object", {
 
-  good_str = "ggplot(iris, aes(x = <span style='color:red;font-size:30px'>Sepal.Length</span>)) + geom_histogram()"
+  good_str = "ggplot(iris, aes(x = <span style=\"color:red;font-size:30px\">Sepal.Length</span>)) + geom_histogram()"
 
-  test_dc <- decorate('ggplot(iris, aes(x = Sepal.Length)) + geom_histogram()', eval = FALSE)
+  test_dc <- decorate("ggplot(iris, aes(x = Sepal.Length)) + geom_histogram()", eval = FALSE)
 
   test_result <- flair_rx(test_dc, test_regexp, color = "red", size = "30px")
 

--- a/tests/testthat/test-flair_lines.R
+++ b/tests/testthat/test-flair_lines.R
@@ -3,7 +3,7 @@ test_that("flair_lines highlights only some lines", {
 This is line 2.
 This is line 3.
 This is line 4.'
-  res_text <- "This is line 1.<br><span style='background-color:#ffff7f'>This is line 2.</span><br>This is line 3.<br><span style='background-color:#ffff7f'>This is line 4.</span>"
+  res_text <- "This is line 1.<br><span style=\"background-color:#ffff7f\">This is line 2.</span><br>This is line 3.<br><span style=\"background-color:#ffff7f\">This is line 4.</span>"
   expect_equal(flair_lines(test_text, c(2,4)), res_text)
 })
 
@@ -14,7 +14,7 @@ test_that("flair_lines works on with_flair objects", {
 
   test_result <- flair_lines(test_wf, c(2:4))
 
-  good_str <- "ggplot(iris, aes(x = Sepal.Length)) +<br><span style='background-color:#ffff7f'>  geom_histogram()</span>"
+  good_str <- "ggplot(iris, aes(x = Sepal.Length)) +<br><span style=\"background-color:#ffff7f\">  geom_histogram()</span>"
 
   expect_equal(test_result[[2]]$src, good_str)
   expect_equal(class(test_result[[2]]), "source")

--- a/tests/testthat/test-utils-wrap.R
+++ b/tests/testthat/test-utils-wrap.R
@@ -1,0 +1,46 @@
+test_that("wrap_html() uses `class`", {
+  good_str <- '<span class="flair flair-fancy" style="color:red">CODE</span>'
+
+  expect_equal(
+    wrap_html("CODE", list(color = "red"), class = c("flair", "flair-fancy")),
+    good_str
+  )
+  expect_equal(
+    wrap_html("CODE", list(color = "red"), class = c("flair", "flair-fancy", NA)),
+    good_str
+  )
+  expect_equal(
+    wrap_html("CODE", list(color = "red"), class = c("flair", "flair-fancy", NA, "")),
+    good_str
+  )
+})
+
+test_that("wrap_html() ignore missing `class`", {
+  good_str <- '<span style="color:red">CODE</span>'
+
+  expect_equal(wrap_html("CODE", list(color = "red")), good_str)
+  expect_equal(wrap_html("CODE", list(color = "red"), class = NA), good_str)
+  expect_equal(wrap_html("CODE", list(color = "red"), class = ""), good_str)
+})
+
+test_that("txt_style() passes `class` to wrap_html()", {
+  expect_equal(
+    txt_style("CODE", color = "red", class = c("flair", "flair-fancy")),
+    '<span class="flair flair-fancy" style="color:red">CODE</span>'
+  )
+
+  expect_equal(
+    txt_style("CODE", class = c("flair", "flair-fancy")),
+    '<span class="flair flair-fancy">CODE</span>'
+  )
+
+  expect_equal(
+    txt_style("CODE", bold=TRUE, class = c("flair", "flair-fancy")),
+    '<span class="flair flair-fancy" style="text-weight:bold">CODE</span>'
+  )
+
+  expect_equal(
+    txt_style("I am danger", class = "text-danger"),
+    '<span class="text-danger">I am danger</span>'
+  )
+})


### PR DESCRIPTION
Hi @kbodwin!

I've been enjoying using flair in my slides lately, so first thanks for this awesome package!

One thing that I often want to do is to use classes to style the flair-ed text. This PR primarily updates `wrap_html()` to accept a `class` argument that is accessible via `txt_style()`.

This makes it possible to do some pretty cool things...

![flair-animated](https://user-images.githubusercontent.com/5420529/89563146-ffaaf580-d7e8-11ea-8a6c-758f38b135a5.gif)

<details><summary>Source: <code>animated-flair-demo.Rmd</code></summary>

````markdown
---
output:
  xaringan::moon_reader:
    lib_dir: libs
    seal: false
    nature:
      highlightStyle: github
      highlightLines: true
      countIncrementalSlides: false
---

```{r flair}
library(flair)
xaringanExtra::use_animate_css()
```

```{r}
decorate("flair") %>% 
  flair("flair", 
        class = "animated tada infinite delay-1", 
        display = "inline-block") %>% 
  flair("xaringanExtra::use_animate_css()", 
        class = "animated lightSpeedIn delay-1s", 
        display = "inline-block")
```
````

</details>

I included tests for the `class` argument and updated the docs with an extra example.

While I was working on this I noticed a couple other things:

1. I was confused about where the `...` go in `txt_style()`, I think because I misunderstood the phrase "CSS tag names". I changed this to "CSS property names", since the `...` all become part of the `style` attribute.

1. In `txt_style()` the property names and values for `bold`, `underline` and `italics` were reversed.

1. I updated `wrap_html()` so that the `style` and `class` attributes are only included if there's something to put in them, and I also switched to using double quotes around those elements, e.g. `<span style="...">` instead of `<span style='...'>`. It's really just a style choice.

On that last point, it'd be worth thinking about using `htmltools` instead of `glue` to create the HTML tags. One problem that could arise with the current approach is that it's possible to escape the style string and open a new attribute or tag. I mean, I doubt anyone is really running into this, but it could create odd bugs down the line. (It's how I was doing this class business before this PR.)

```r
txt_style('test', color = 'red;" class="wait-a-second')
## <span style="color:red;" class="wait-a-second">test</span>
```

Let me know if you have any questions, comments, feedback, etc. and I'll be happy to answer or update the PR!