### PR TITLE
Fixes for dev stringr

### DIFF
--- a/R/chunk_addin.R
+++ b/R/chunk_addin.R
@@ -40,7 +40,7 @@ add_flair_chunk  <- function(x) {
 
   chunk_params <- stringr::str_split(chunk_header, ", *")[[1]]
 
-  if (all(stringr::str_detect(chunk_params, "=")) || chunk_params == "") {
+  if (all(stringr::str_detect(chunk_params, "=")) || all(chunk_params == "")) {
     stop("Chunk must be named")
   }
 

--- a/R/flair.R
+++ b/R/flair.R
@@ -93,6 +93,7 @@ flair_rx.default <- function(x, pattern,
   # rx_between <- "((?<=\\>|^)([^\\<]|(\\<(?=(\\-|\\<))))*(?=\\<|$))"
 
   split_string <- x %>%
+    as.character() %>%
     str_extract_all("(\\<[^\\<\\>]*\\>)|((?<=\\>|^)([^\\<]|(\\<(?=(\\-|\\<))))*(?=\\<|$))") %>%
     unlist()
 

--- a/R/flair_lines.R
+++ b/R/flair_lines.R
@@ -58,7 +58,7 @@ flair_lines.decorated <- function(x, lines) {
 
   line_nums <-
     x[where_sources] %>%
-    map(~str_count(.x, "\\n|(<br>)")) %>%
+    map(~str_count(as.character(.x), "\\n|(<br>)")) %>%
     map2(1:sum(where_sources), ~ 0:.x + .y)
 
   to_flair <- unlist(map(line_nums, ~any(.x %in% lines)))
@@ -92,7 +92,7 @@ flair_lines.decorated <- function(x, lines) {
 #' @importFrom stringr str_split str_c
 flair_sublines <- function(text, nums, lines) {
   which_lines <- which(nums %in% lines)
-  text <- text %>% str_split("\\n|(<br>)") %>% unlist()
+  text <- text %>% as.character() %>% str_split("\\n|(<br>)") %>% unlist()
   text[which_lines] <- map(text[which_lines], function(cs) flair_quick(cs, ".+"))
   text <- str_c(text, collapse = "<br>")
   return(text)


### PR DESCRIPTION
stringr 1.5.0 will require inputs be vectors so I had to coerce the source objects in a couple of places. (I also fixed an warning about a vector in an `if` condition, you should double check that `all()` is correct here).