### PR TITLE
Fix chunk identification regex

### DIFF
--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -187,12 +187,10 @@ src_to_list <- function(knitted) {
     split_sandwiches("```\\s*[A-Za-z]*") %>%
     as.list()
 
-  before_code <- which(stringr::str_detect(knitted, "```\\s*[A-Za-z]*"))
-
-  knitted[before_code + 1] <- stringr::str_trim(knitted[before_code + 1])
+  before_code <- which(stringr::str_detect(knitted, "```\\s*[A-Za-z]+"))
 
   knitted[before_code + 1] <- purrr::map(knitted[before_code + 1],
-                                         as_decorated_source)
+                                         ~as_decorated_source(stringr::str_trim(.x)))
 
   knitted <- knitted[-c(before_code, before_code + 2)]
 

--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -184,10 +184,10 @@ decorate_chunk <- function(chunk_name,
 src_to_list <- function(knitted) {
 
   knitted <- knitted %>%
-    split_sandwiches("```[A-z]*") %>%
+    split_sandwiches("```\\s*[A-Za-z]*") %>%
     as.list()
 
-  before_code <- which(stringr::str_detect(knitted, "```[A-z]+"))
+  before_code <- which(stringr::str_detect(knitted, "```\\s*[A-Za-z]*"))
 
   knitted[before_code + 1] <- stringr::str_trim(knitted[before_code + 1])
 

--- a/R/decorate_code.R
+++ b/R/decorate_code.R
@@ -56,7 +56,15 @@ decorate_code <- function(text, ...) {
 
   }
 
-  my_code_fenced <- paste0("```{r}\n", text, "\n```")
+  # Build chunk header with user-provided chunk options
+  user_opts <- list(...)
+
+  if (length(user_opts) > 0) {
+    opts_string <- toString(list_to_strings(user_opts))
+    my_code_fenced <- paste0("```{r, ", opts_string, "}\n", text, "\n```")
+  } else {
+    my_code_fenced <- paste0("```{r}\n", text, "\n```")
+  }
 
   if (is_live) {
 


### PR DESCRIPTION
At some point in the past, kntir/rmarkdown/something changed how it was outputting chunks of code so that instead of outputting `` ```r `` it added a space between the backticks and the language name creating `` ``` r ``

This broke all rendering functions (see #46), since `decorate()` could no longer find any matches to decorate. 

Here, I updated the regex to allow for optional whitespace between the backticks and the language name, and everything works!

```r
# Before
split_sandwiches("```[A-z]*")
str_detect(knitted, "```[A-z]+")

# After
split_sandwiches("```\\s*[A-Za-z]*")
str_detect(knitted, "```\\s*[A-Za-z]+")
```